### PR TITLE
Package dependencies and pip cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,70 @@
+name:  Test Build
+
+on: workflow_dispatch
+
+jobs:
+  test:
+    name: Tests on ${{ matrix.arch }} with Conda Python-${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: "3.10"
+            arch: Linux-x86_64
+          - os: ubuntu-latest
+            python: "3.11"
+            arch: Linux-x86_64
+          - os: macos-latest
+            python: "3.10"
+            arch: MacOSX-x86_64
+          - os: macos-latest
+            python: "3.11"
+            arch: MacOSX-x86_64
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Conda Base
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          channels: conda-forge
+          use-only-tar-bz2: true  # IMPORTANT: Needed for caching to work properly!
+          auto-update-conda: true
+          auto-activate-base: true
+
+      - name: Check Conda Config
+        run: |
+          conda activate base
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
+
+      - name: Install
+        run: |
+          ./soconda.sh -e soconda -v CI
+
+      - name: Run Tests
+        run: |
+          conda activate "soconda_CI"
+          export OMP_NUM_THREADS=2
+          export MPI_DISABLE=1
+          test_pixell.py
+          python3 -c 'import toast.tests; toast.tests.run()'
+          git clone --depth=1 --single-branch --branch=master https://github.com/simonsobs/sotodlib.git
+          pushd sotodlib
+          python3 setup.py test
+          popd
+          unset MPI_DISABLE
+          unset OMP_NUM_THREADS

--- a/deploy/init_nersc_lmod
+++ b/deploy/init_nersc_lmod
@@ -1,2 +1,1 @@
--- Load the NERSC Anaconda base
-depends_on("python")
+-- No module dependencies

--- a/deploy/install_perlmutter.sh
+++ b/deploy/install_perlmutter.sh
@@ -49,7 +49,7 @@ if [ -d "${clone_dir}" ]; then
     rm -rf "${clone_dir}"
 fi
 
-git clone --depth=1 --single-branch --branch=${version} https://github.com/tskisner/soconda.git "${clone_dir}" >> "${logfile}" 2>&1
+git clone --depth=1 --single-branch --branch=${version} https://github.com/simonsobs/soconda.git "${clone_dir}" >> "${logfile}" 2>&1
 
 # Activate the base environment
 source "${base_dir}/etc/profile.d/conda.sh"

--- a/deploy/scron_check_tag.slurm
+++ b/deploy/scron_check_tag.slurm
@@ -1,6 +1,15 @@
+# OPTION 1
+#
 #SCRON --qos=workflow
 #SCRON --account=mp107
 #SCRON --time=03:00:00
 #SCRON --dependency=singleton
 #SCRON --name=soconda_latest_tag
-0 * * * * /global/u2/s/sobs/software/git/soconda/deploy/install_nersc_tag.sh
+#44 * * * * /global/homes/s/sobs/software/git/soconda/deploy/install_nersc_tag.sh
+#
+# OPTION 2
+#
+#SCRON -q cron
+#SCRON -A mp107
+#SCRON -t 03:00:00
+#44 * * * * /global/homes/s/sobs/software/git/soconda/deploy/install_nersc_tag.sh

--- a/packages_local.txt
+++ b/packages_local.txt
@@ -1,7 +1,7 @@
 pixell
-#libactpol_deps
-#libactpol
-#moby2
+libactpol_deps
+libactpol
+moby2
 # Remove next line once toast-3.0 is on conda-forge,
 # and move to packages_conda.txt
 toast

--- a/pkgs/libactpol/meta.yaml
+++ b/pkgs/libactpol/meta.yaml
@@ -30,11 +30,14 @@ requirements:
     - cfitsio
     - wcslib
     - libactpol_deps
+    # This constraint is to enforce compatibility with older cfitsio
+    # Remove this once healpy package is using latest wcslib / cfitsio.
+    - healpy
   run:
     - openblas * openmp_*
-    - cfitsio
-    - wcslib
-    - libactpol_deps
+    - {{ pin_compatible('cfitsio') }}
+    - {{ pin_compatible('wcslib') }}
+    - {{ pin_compatible('libactpol_deps') }}
 
 test:
   commands:

--- a/pkgs/libactpol_deps/meta.yaml
+++ b/pkgs/libactpol_deps/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - zziplib
   run:
     - openblas * openmp_*
-    - zziplib
+    - {{ pin_compatible('zziplib') }}
 
 test:
   commands:

--- a/pkgs/moby2/meta.yaml
+++ b/pkgs/moby2/meta.yaml
@@ -39,10 +39,10 @@ requirements:
   run:
     - python
     - openblas * openmp_*
-    - {{ pin_compatible("fftw") }}
-    - gsl
-    - libactpol
-    - numpy
+    - {{ pin_compatible('fftw') }}
+    - {{ pin_compatible('gsl') }}
+    - {{ pin_compatible('libactpol') }}
+    - {{ pin_compatible('numpy') }}
     - future
     - scipy
     - matplotlib

--- a/pkgs/so3g/meta.yaml
+++ b/pkgs/so3g/meta.yaml
@@ -43,11 +43,11 @@ requirements:
     - libflac
   run:
     - python
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - openblas * openmp_*
-    - {{ pin_compatible("liblapack") }}
-    - {{ pin_compatible("boost") }}
-    - {{ pin_compatible("libflac") }}
+    - {{ pin_compatible('liblapack') }}
+    - {{ pin_compatible('boost') }}
+    - {{ pin_compatible('libflac') }}
     - astropy
     - matplotlib
     - scipy

--- a/pkgs/toast/meta.yaml
+++ b/pkgs/toast/meta.yaml
@@ -39,12 +39,12 @@ requirements:
   run:
     - llvm-openmp >=4.0.1  # [osx]
     - python
-    - {{ pin_compatible("fftw") }}
+    - {{ pin_compatible('fftw') }}
     - openblas * openmp_*
-    - {{ pin_compatible("liblapack") }}
-    - {{ pin_compatible("suitesparse") }}
-    - {{ pin_compatible("libaatm") }}
-    - {{ pin_compatible("libflac") }}
+    - {{ pin_compatible('liblapack') }}
+    - {{ pin_compatible('suitesparse') }}
+    - {{ pin_compatible('libaatm') }}
+    - {{ pin_compatible('libflac') }}
     - numpy
     - scipy
     - matplotlib

--- a/soconda.sh
+++ b/soconda.sh
@@ -246,7 +246,7 @@ while IFS='' read -r line || [[ -n "${line}" ]]; do
             done
         fi
         echo "Installing package ${pkg}"
-        python3 -m pip install --no-deps ${pkg} | tee -a "log_pip" 2>&1
+        python3 -m pip install ${pkg} | tee -a "log_pip" 2>&1
     fi
 done < "${scriptdir}/packages_pip.txt"
 

--- a/soconda.sh
+++ b/soconda.sh
@@ -135,9 +135,6 @@ if [ "x${env_check}" = "x" ]; then
     conda deactivate
     conda activate "${fullenv}"
 
-    # Update conda and low-level tools
-    conda update --all
-
     # Copy logo files
     cp "${scriptdir}"/logo*.png "${CONDA_PREFIX}/"
 else
@@ -166,6 +163,12 @@ rm -f "${CONDA_PREFIX}/bin/cc"
 
 conda deactivate
 conda activate "${fullenv}"
+
+# Update conda and low-level tools, including pipgrip which we
+# use to install dependencies of pip packages with conda.
+conda update --yes --all
+conda install --yes setuptools wheel anytree click packaging
+python3 -m pip install pipgrip
 
 mkdir -p "${CONDA_PREFIX}/conda-bld"
 conda-index "${CONDA_PREFIX}/conda-bld"
@@ -222,8 +225,28 @@ while IFS='' read -r line || [[ -n "${line}" ]]; do
     comment=$(echo "${line}" | cut -c 1)
     if [ "${comment}" != "#" ]; then
         pkg="${line}"
+        url_check=$(echo "${pkg}" | grep '/')
+        if [ "x${url_check}" = "x" ]; then
+            echo "Checking dependencies for package \"${pkg}\""
+            for dep in $(pipgrip --pipe ${pkg}); do
+                name=$(echo ${dep} | sed -e 's/\([[:alnum:]_\-]*\).*/\1/')
+                if [ "${name}" != "${pkg}" ]; then
+                    depcheck=$(conda list ${name} | awk '{print $1}' | grep -E "^${name}\$")
+                    if [ "x${depcheck}" = "x" ]; then
+                        # It is not already installed, try to install it with conda
+                        echo "Attempt to install conda package for dependency \"${name}\"..." | tee -a "log_pip" 2>&1
+                        conda install --yes ${name} | tee -a "log_pip" 2>&1
+                        if [ $? -ne 0 ]; then
+                            echo "  No conda package available for dependency \"${name}\"" | tee -a "log_pip" 2>&1
+                        fi
+                    else
+                        echo "  Package for dependency \"${name}\" already installed" | tee -a "log_pip" 2>&1
+                    fi
+                fi
+            done
+        fi
         echo "Installing package ${pkg}"
-        pip install --no-deps ${pkg} | tee -a "log_pip" 2>&1
+        python3 -m pip install --no-deps ${pkg} | tee -a "log_pip" 2>&1
     fi
 done < "${scriptdir}/packages_pip.txt"
 


### PR DESCRIPTION
* Avoid a conflict in libactpol local packages with the combination of cfitsio, wcslib, and healpy

* Parse pip package dependencies with pipgrip and install as many as possible with conda

* For local conda packages using compiled dependencies, pin the runtime package versions to the build time ABI

Fixes #1