### PR TITLE
Split upstream and local installs.

### DIFF
--- a/pkgs/libactpol/meta.yaml
+++ b/pkgs/libactpol/meta.yaml
@@ -31,12 +31,11 @@ requirements:
     - _openmp_mutex * *_llvm
     - libopenblas * openmp_*
     - openblas * openmp_*
-    - cfitsio
+    # This constraint is to force compatibility with the healpy package.
+    # remove once healpy is building with cfitsio-4.4.x.
+    - cfitsio <4.4.0
     - wcslib
     - libactpol_deps
-    # This constraint is to enforce compatibility with older cfitsio
-    # Remove this once healpy package is using latest wcslib / cfitsio.
-    - healpy
     # Remove until this perl bug is fixed
     # https://github.com/conda-forge/perl-feedstock/issues/56
     - libxcrypt1   # [linux]

--- a/soconda.sh
+++ b/soconda.sh
@@ -249,12 +249,21 @@ rm -rf "${conda_tmp}" &> /dev/null
 find "/tmp" -maxdepth 1 -type f -name 'pixell-*' -exec rm {} \;
 
 
-# Install local and upstream conda packages all at once.
+# Install upstream conda packages.
 echo -e "\n\n"
 echo "Installing conda packages..." | tee "log_conda"
-conda_exec install --yes ${local_pkgs} \
+conda_exec install --yes \
     --file "${scriptdir}/config/common.txt" \
     --file "${confdir}/packages_conda.txt" \
+    2>&1 | tee -a "log_conda"
+
+conda_exec deactivate
+conda_exec activate "${fullenv}"
+
+# Install local conda packages.
+echo -e "\n\n"
+echo "Installing local packages..." | tee -a "log_conda"
+conda_exec install --yes --use-local ${local_pkgs} \
     2>&1 | tee -a "log_conda"
 
 conda_exec deactivate


### PR DESCRIPTION
This restores the conda install into two commands, which I mistakenly changed in the last PR.  This is needed to ensure that the locally built packages are installed with the --use-local option.  Also clean up cfitsio pinning.