### PR TITLE
Run tests on macos arm-based runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   test:
-    name: Tests on ${{ matrix.arch }} with Conda Python-${{ matrix.python }}
+    name: Conda ${{ matrix.arch }} on ${{ matrix.os }} with Python ${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     env:
       CI: "1"
@@ -39,7 +39,7 @@ jobs:
         run: |
           rm -rf /usr/share/miniconda
           rm -rf /usr/local/miniconda
-          ./tools/bootstrap_base.sh ~/conda
+          ./tools/bootstrap_base.sh ~/conda ${{ matrix.arch }}
 
       - name: Check Conda Config
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
           - os: ubuntu-latest
             python: "3.11"
             arch: Linux-x86_64
-          - os: macos-latest
-            python: "3.10"
+          - os: macos-12
+            python: "3.11"
             arch: MacOSX-x86_64
-          - os: macos-latest
+          - os: macos-14
             python: "3.11"
             arch: MacOSX-x86_64
     steps:
@@ -57,7 +57,7 @@ jobs:
           pyver=${{ matrix.python }} &&
           sed -i -E "s/python=3\.[[:digit:]]+.*/python=${pyver}/" ./config/default/packages_conda.txt &&
           cat ./config/default/packages_conda.txt &&
-          if [ ${{ matrix.os }} = "macos-latest" ]; then \
+          if [[ ${{ matrix.os }} == "macos-12" || ${{ matrix.os }} == "macos-14" ]]; then \
             ./soconda.sh -e soconda -v CI -c binary; \
           else \
             ./soconda.sh -e soconda -v CI -c default; \

--- a/tools/bootstrap_base.sh
+++ b/tools/bootstrap_base.sh
@@ -7,18 +7,25 @@ popd >/dev/null 2>&1
 
 show_help () {
     echo "" >&2
-    echo "Usage:  $0 <base install directory>" >&2
+    echo "Usage:  $0 <base install directory> <optional arch string>" >&2
     echo "" >&2
 }
 
 base=$1
+arch=$2
 
 if [ -z ${base} ]; then
     show_help
     exit 1
 fi
 
-inst=$(eval "${scriptdir}/fetch_check.sh" https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh miniforge.sh)
+if [ -z ${arch} ]; then
+    arch="$(uname)-$(uname -m)"
+fi
+
+echo "Bootstrap conda base for architecture ${arch} ..."
+
+inst=$(eval "${scriptdir}/fetch_check.sh" https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${arch}.sh miniforge.sh)
 
 bash "${inst}" -b -f -p "${base}"
 


### PR DESCRIPTION
At least 2 users have reported crashes running on apple arm chips using the x86_64 conda-forge stack.  This branch is just an attempt to reproduce it and see if it is easily fixed.