### PR TITLE
Use PYTHONPATH instead of PYTHONUSERBASE in jupyter kernel files.

### DIFF
--- a/templates/jupyter.sh.in
+++ b/templates/jupyter.sh.in
@@ -21,7 +21,7 @@ echo '
     "display_name": "soconda @VERSION@",
     "env": {
         "PATH": "@ENVPREFIX@/bin",
-        "PYTHONUSERBASE": "${HOME}/.local/soconda/@VERSION@/lib/python@PYVER@/site-packages"
+        "PYTHONPATH": "${HOME}/.local/soconda/@VERSION@/lib/python@PYVER@/site-packages"
     },
     "metadata": {
         "debugger": true


### PR DESCRIPTION
With this small change, I verified that doing `pip install --user .` from an sotodlib checkout works inside a jupyter session.  This user version of sotodlib is found before the version installed with soconda.