### PR TITLE
Update meta.yaml

### DIFF
--- a/pkgs/so3g/meta.yaml
+++ b/pkgs/so3g/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.1.13" %}
-{% set sha256 = "468b1a813fa1baf1134f7041898380b0552fe3a02f0fdbe450ac1e452bbae349" %}
+{% set sha256 = "48a1f66ba1eca0c6035780257b70eafd1fd9651a0dcec31a74f7143851480a71" %}
 
 {% set build = 0 %}
 


### PR DESCRIPTION
While trying to install a new soconda on Princeton Della for development purposes, I got the following error while compiling so3g:

```
SHA256 mismatch: '48a1f66ba1eca0c6035780257b70eafd1fd9651a0dcec31a74f7143851480a71' != '468b1a813fa1baf1134f7041898380b0552fe3a02f0fdbe450ac1e452bbae349'
```

I updated the YAML file as this PR and so3g was installed correctly. It may be a general diff from so3g.

