### PR TITLE
Fix several small issues and add dockerfile example.

### DIFF
--- a/Dockerfile_jupyter
+++ b/Dockerfile_jupyter
@@ -1,0 +1,43 @@
+FROM quay.io/jupyter/minimal-notebook:latest as builder
+
+MAINTAINER Theodore Kisner <tskisner@lbl.gov>
+
+# Use bash
+
+SHELL ["/bin/bash", "-c"]
+
+# Copy files into container
+
+COPY soconda.sh ./soconda.sh
+
+RUN mkdir -p config
+COPY config ./config/
+
+RUN mkdir -p deploy
+COPY deploy ./deploy/
+
+RUN mkdir -p pkgs
+COPY pkgs ./pkgs/
+
+RUN mkdir -p templates
+COPY templates ./templates/
+
+RUN mkdir -p tools
+COPY tools ./tools/
+
+# Install packages to the base environment
+
+RUN ./deploy/install_docker_jupyter.sh
+
+# ======================================
+
+FROM quay.io/jupyter/minimal-notebook:latest
+
+# Copy our installed software binaries and libraries
+
+COPY --from=builder /opt/conda /opt/conda/
+
+# Imports to create config files
+
+RUN python3 -c "import astropy"
+RUN python3 -c "import matplotlib.font_manager as fm; f = fm.FontManager"

--- a/config/site/packages_conda.txt
+++ b/config/site/packages_conda.txt
@@ -1,5 +1,5 @@
 # Adjust the default python version
-python=3.10.*
+python=3.11.*
 #
 wurlitzer
 plotly

--- a/config/site/packages_conda.txt
+++ b/config/site/packages_conda.txt
@@ -1,5 +1,5 @@
 # Adjust the default python version
-python=3.11.*
+python=3.10.*
 #
 wurlitzer
 plotly

--- a/deploy/install_docker_jupyter.sh
+++ b/deploy/install_docker_jupyter.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This assumes that a conda base environment already exists
+# in /opt/conda, and that we want to install soconda directly
+# to the base environment.
+
+# Location for conda base
+base_dir=/opt/conda
+
+# Location of soconda tree.  This is assumed to be already
+# checked out to the desired branch / tag.  This is useful for
+# testing if the source tree is bind-mounted somewhere else.
+git_dir="."
+
+# Temp package dir
+pkg_temp=${HOME}/temp_pkgs
+mkdir -p ${pkg_temp}
+export CONDA_PKGS_DIRS=${pkg_temp}
+
+#===========================================
+
+# Base environment is already activated
+conda update -n base --yes --all conda
+conda install -n base --yes --all conda-build conda-verify
+
+# Build things from the default home directory
+
+eval "${git_dir}/soconda.sh" \
+    -v "$(date +%Y%m%d)" \
+    -c "site" \
+    -b "/opt/conda" \
+    -e "base"
+
+# Remove pkg cache
+rm -rf ${pkg_temp}

--- a/pkgs/libactpol_deps/build.sh
+++ b/pkgs/libactpol_deps/build.sh
@@ -15,8 +15,8 @@ popd
 pushd slim_v2_7_1-moby2-1
 CFLAGS="-O3 -g -fPIC" \
 CXXFLAGS="-O3 -g -fPIC" \
-./configure --prefix="${PREFIX}" --with-zzip
-make
+./configure --prefix="${PREFIX}" --with-zzip && \
+make && \
 make install
 rm -f "${PREFIX}/lib/libactpol_deps*.la"
 popd

--- a/pkgs/libactpol_deps/gcc_hardcode.patch
+++ b/pkgs/libactpol_deps/gcc_hardcode.patch
@@ -1,0 +1,12 @@
+diff -urN libactpol_deps_orig/sofa_20180130/Makefile libactpol_deps_new/sofa_20180130/Makefile
+--- libactpol_deps_orig/sofa_20180130/Makefile	2020-06-22 15:49:10.000000000 -0700
++++ libactpol_deps_new/sofa_20180130/Makefile	2024-04-26 16:56:59.751864213 -0700
+@@ -23,7 +23,7 @@
+ default: $(LIBNAME)
+ 
+ $(LIBNAME): $(OBJECTS)
+-	gcc -shared -Wl,-soname,$@.1 \
++	$(CC) -shared -Wl,-soname,$@.1 \
+ 	    -o $@ $(OBJECTS)
+ 
+ clean:

--- a/pkgs/libactpol_deps/meta.yaml
+++ b/pkgs/libactpol_deps/meta.yaml
@@ -10,6 +10,8 @@ package:
 source:
   url: https://github.com/ACTCollaboration/libactpol_deps/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - gcc_hardcode.patch
 
 build:
   number: {{ build }}
@@ -18,6 +20,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
     - llvm-openmp # [osx]
     - automake

--- a/soconda.sh
+++ b/soconda.sh
@@ -68,7 +68,14 @@ if [ -z "${envname}" ]; then
     envname="soconda"
 fi
 # The full environment name, including the root and version.
-fullenv="${envname}_${version}"
+if [ "${envname}" = "base" ]; then
+    # We are installing directly to the base conda env.  This is normally
+    # a bad idea, but sometimes makes sense (e.g. inside a docker
+    # container).
+    fullenv="base"
+else
+    fullenv="${envname}_${version}"
+fi
 # Determine whether the new environment is a name or a full path.
 env_noslash=$(echo "${fullenv}" | sed -e 's/\///g')
 if [ "${env_noslash}" != "${fullenv}" ]; then
@@ -220,6 +227,8 @@ if [ -z "${env_check}" ]; then
 else
     echo "Activating environment \"${fullenv}\""
     conda_exec activate "${fullenv}"
+    # Ensure that the build folder is added to the channel list
+    conda config --env --add channels "file://${CONDA_PREFIX}/conda-bld"
 fi
 conda_exec env list
 
@@ -370,3 +379,6 @@ fi
 if [ -n "${install_jupyter_setup}" ]; then
     source "${scriptdir}/tools/install_jupyter_setup.sh"
 fi
+
+# Clean up
+conda clean --all --yes


### PR DESCRIPTION
This adds support for installing soconda directly into the `base` environment, which is useful when running in a docker container.  This also adds an example dockerfile and install script.  Tested with:
```
docker build -f Dockerfile_jupyter .
```
Feedback welcome!