### PR TITLE
Pin numpy verstion to 1.26

### DIFF
--- a/config/common.txt
+++ b/config/common.txt
@@ -18,7 +18,7 @@ libblas=*=*openblas
 #
 # Install requirements of our local and pip packages
 #
-numpy
+numpy=1.26
 scipy
 matplotlib
 cmake

--- a/pkgs/moby2/meta.yaml
+++ b/pkgs/moby2/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - gsl
     - libactpol
     - future
-    - numpy >=1.26
+    - numpy =1.26
     - scipy
     # Although not a dependency, we put numba here to force
     # building with a numba-compatible numpy version

--- a/pkgs/pixell/meta.yaml
+++ b/pkgs/pixell/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - libblas * *openblas
     - python
     - cython
-    - numpy >=1.26
+    - numpy =1.26
     - scipy
     - astropy
     - healpy

--- a/pkgs/qpoint/meta.yaml
+++ b/pkgs/qpoint/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - libblas * *openblas
     - python
     - setuptools
-    - numpy >=1.26
+    - numpy =1.26
     - scipy
     # Although not a dependency, we put numba here to force
     # building with a numba-compatible numpy version

--- a/pkgs/so3g/meta.yaml
+++ b/pkgs/so3g/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - libblas * *openblas
     - openblas * *openmp*
     - python
-    - numpy >=1.26
+    - numpy =1.26
     - scipy
     - boost
     - libboost-devel

--- a/pkgs/toast/meta.yaml
+++ b/pkgs/toast/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - libopenblas * *openmp*
     - libblas * *openblas
     - python
-    - numpy >=1.26
+    - numpy =1.26
     - scipy
     - fftw
     - suitesparse <7.3

--- a/soconda.sh
+++ b/soconda.sh
@@ -257,6 +257,7 @@ while IFS='' read -r line || [[ -n "${line}" ]]; do
         echo "Building local package '${pkgname}'" 2>&1 | tee "log_${pkgname}"
         conda build \
             --variants "{'python':['${python_major_minor}']}" \
+            --numpy 1.26 \
             ${pkgrecipe} 2>&1 | tee -a "log_${pkgname}"
     fi
 done < "${confdir}/packages_local.txt"


### PR DESCRIPTION
Numpy 2.0.0 released few days ago. [1]

`so3g` failed to compile with numpy=2.0.0
It seems to related to C API `PyArray_Descr` change [2] and affect at least [G3Ndarray.cxx](https://github.com/simonsobs/so3g/blob/master/src/G3Ndarray.cxx) file.

This PR pin numpy to version 1.26 globally before upstream fix compatibility.

[1] https://github.com/numpy/numpy/releases/tag/v2.0.0
[2] https://numpy.org/doc/stable/release/2.0.0-notes.html#c-api-changes