### PR TITLE
Update sha256sum

### DIFF
--- a/pkgs/pixell/meta.yaml
+++ b/pkgs/pixell/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/simonsobs/pixell/archive/v{{ version }}.tar.gz
+  url: https://github.com/simonsobs/pixell/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - qsort_const.patch

--- a/pkgs/qpoint/meta.yaml
+++ b/pkgs/qpoint/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/arahlin/qpoint/archive/{{ version }}.tar.gz
+  url: https://github.com/arahlin/qpoint/archive/refs/tags/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/pkgs/so3g/meta.yaml
+++ b/pkgs/so3g/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/simonsobs/so3g/archive/v{{ version }}.tar.gz
+  url: https://github.com/simonsobs/so3g/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - setup_requires.patch

--- a/pkgs/so3g/meta.yaml
+++ b/pkgs/so3g/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.1.15" %}
-{% set sha256 = "c8a0a9dc5846c9ba97510db6844b9699ffce10ad882a7bcb9317fa204909c56f" %}
+{% set sha256 = "172b203c0f6395c4482d32a8e74f247761f0e380729a8357ef76bc23a581a46c" %}
 
 {% set build = 0 %}
 

--- a/pkgs/zziplib/meta.yaml
+++ b/pkgs/zziplib/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/gdraheim/zziplib/archive/v{{ version }}.tar.gz
+  url: https://github.com/gdraheim/zziplib/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
Also using `/archive/refs/tags/` check sum hash may be more stable. Some conflicting information:

- Could improve hash stability: https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1029861300
- This doesn't change anything unless upload tarball to GitHub: https://github.com/orgs/community/discussions/45830#discussioncomment-4823531