### PR TITLE
Update common packages

### DIFF
--- a/config/common.txt
+++ b/config/common.txt
@@ -64,3 +64,4 @@ pyfftw
 numdifftools
 namaster
 pysm3
+lmfit


### PR DESCRIPTION
As of simonsobs/sotodlib#984 sotodlib requires `lmfit`.