### PR TITLE
Make sure moby2 use NaMaster-compatible GSL version.

### DIFF
--- a/pkgs/moby2/meta.yaml
+++ b/pkgs/moby2/meta.yaml
@@ -36,6 +36,8 @@ requirements:
     # Although not a dependency, we put numba here to force
     # building with a numba-compatible numpy version
     - numba
+    # Not a dependency, force installing a NaMaster-compatible GSL version
+    - namaster
   run:
     - llvm-openmp # [osx]
     - libopenblas * *openmp*


### PR DESCRIPTION
I got following error when installing local package `moby2`
```
LibMambaUnsatisfiableError: Encountered problems while solving:
  - package namaster-2.3.3-py311hf914bfa_1 requires gsl >=2.7,<2.8.0a0, but none of the providers can be installed
                                                     
Could not solve for environment specs                
The following packages are incompatible              
├─ moby2 =* * is installable and it requires         
│  └─ gsl >=2.8,<2.9.0a0 *, which can be installed;
├─ namaster =* * is installable with the potential options
│  ├─ namaster [1.2|1.2.2|...|2.3.3] would require
│  │  └─ gsl >=2.7,<2.8.0a0 *, which conflicts with any installable versions previously reported;
│  ├─ namaster [0.9|1.0|1.0.1|1.0.2] would require
│  │  └─ python >=2.7,<2.8.0a0 *, which can be installed;
│  ├─ namaster [0.9|1.0|...|1.2] would require
│  │  └─ python >=3.6,<3.7.0a0 *, which can be installed;
│  ├─ namaster [0.9|1.0|...|1.2] would require
│  │  └─ python >=3.7,<3.8.0a0 *, which can be installed;
│  ├─ namaster [1.0|1.0.1|1.0.2|1.1|1.2] would require
│  │  └─ python >=3.8,<3.9.0a0 *, which can be installed;
│  └─ namaster [1.1|1.2] would require
│     └─ python >=3.9,<3.10.0a0 *, which can be installed;
└─ pin on python 3.11.* =* * is not installable because it requires
   └─ python =3.11 *, which conflicts with any installable versions previously reported.

Pins seem to be involved in the conflict. Currently pinned specs:
 - python=3.11
```

This is due to namaster requires `gsl < 2.8` but when building `moby2` package it pulls `gsl 2.8` and pinned that version https://github.com/simonsobs/soconda/blob/1d45e96e2b8dfb2d369aff4f84c74f400ac0ccb2/pkgs/moby2/meta.yaml#L48
which caused conflict.

A quick fix I did here is to add `namaster` package so that when building `moby2` it will pull compatible GSL.