### PR TITLE
adding environment file

### DIFF
--- a/config/tiger3/env.sh
+++ b/config/tiger3/env.sh
@@ -1,0 +1,1 @@
+MPICC=$(which mpicc)

--- a/soconda.sh
+++ b/soconda.sh
@@ -114,8 +114,8 @@ if [ -e "${confdir}/required_modules.txt" ]; then
     done < "${confdir}/required_modules.txt"
 fi
 
-if [ ${HOSTNAME} = "tiger3.princeton.edu"]; then
-    MPICC=$(which mpicc)
+if [ -e "${confdir}/env.sh" ]; then
+    source "${confdir}/env.sh"
 fi
 
 is_micromamba='no'


### PR DESCRIPTION
Sorry Ted for the bug.

Here is the change you suggested. I tested on Tiger3 while commenting out the rest locally:
```bash
ip8725@tiger3:/scratch/gpfs/SIMONSOBS/users/ip8725/soconda$ ./soconda.sh -e test -v 062 -c tiger3
Using config "tiger3"
/usr/local/openmpi/4.1.6/gcc/bin/mpicc
```