### PR TITLE
Fix compatibility with namaster

### DIFF
--- a/pkgs/libactpol/meta.yaml
+++ b/pkgs/libactpol/meta.yaml
@@ -35,6 +35,8 @@ requirements:
     # Remove until this perl bug is fixed
     # https://github.com/conda-forge/perl-feedstock/issues/56
     - libxcrypt1   # [linux]
+    # Not a dependency, force installing a NaMaster-compatible CFITSIO version
+    - namaster >=2.4
   run:
     - llvm-openmp # [osx]
     - libopenblas * *openmp*

--- a/pkgs/moby2/meta.yaml
+++ b/pkgs/moby2/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     # building with a numba-compatible numpy version
     - numba
     # Not a dependency, force installing a NaMaster-compatible GSL version
-    - namaster
+    - namaster >=2.4
   run:
     - llvm-openmp # [osx]
     - libopenblas * *openmp*

--- a/pkgs/so3g/meta.yaml
+++ b/pkgs/so3g/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     # building with a numba-compatible numpy version
     - numba
     # Not a dependency, force installing a NaMaster-compatible GSL version
-    - namaster
+    - namaster >=2.4
   run:
     - llvm-openmp # [osx]
     - libopenblas * *openmp*


### PR DESCRIPTION
- Namaster uses both cfitsio and gsl.  Add a package pin to libactpol so that the cfitsio version used for our build matches the namaster version.

- Pin namaster dependency to >=2.4, since otherwise an early version (1.0) without a cfitsio dependency is selected.

- Tested inside a rockylinux:9 docker container.