### PR TITLE
Add hdf5 module load in config/universe/build_env.sh

### DIFF
--- a/config/universe/build_env.sh
+++ b/config/universe/build_env.sh
@@ -1,3 +1,3 @@
 module use /cephfs/soukdata/software/modulefiles/
-module load openmpi/4.1.6
+module load openmpi/4.1.6 hdf5/1.14.6
 MPICC=$(which mpicc)


### PR DESCRIPTION
Add hdf5 module load in config/universe/build_env.sh so the hdf5 module built against MPICC is loaded for soconda build. 