### PR TITLE
sotodlib added a new dependency on numpy-quaternion

### DIFF
--- a/config/common.txt
+++ b/config/common.txt
@@ -71,3 +71,4 @@ psycopg2-binary
 versioneer
 wurlitzer
 pixell
+quaternion


### PR DESCRIPTION
In the conda ecosystem, this package is called "quaternion".  Since we install sotodlib with --no-deps (due to requirements listing PyPI names of packages and not conda names), this will cause breakage.