### PR TITLE
Generalize update_resource

### DIFF
--- a/config/perlmutter/post_install.sh
+++ b/config/perlmutter/post_install.sh
@@ -18,4 +18,5 @@ install_jupyter_setup=yes
 python ${scriptdir}/tools/update_resource.py \
        --config ${config} \
        --base-json ${scriptdir}/templates/resource_so.json \
-       --output-json ${CONDA_PREFIX}/lib/python${python_major_minor}/site-packages/radical/pilot/configs/resource_so.json
+       --output-json ${CONDA_PREFIX}/lib/python${python_major_minor}/site-packages/radical/pilot/configs/resource_so.json \
+       --env-path ${CONDA_PREFIX}

--- a/config/tiger3/post_install.sh
+++ b/config/tiger3/post_install.sh
@@ -18,4 +18,5 @@ install_jupyter_setup=no
 python ${scriptdir}/tools/update_resource.py \
        --config ${config} \
        --base-json ${scriptdir}/templates/resource_so.json \
-       --output-json ${CONDA_PREFIX}/lib/python${python_major_minor}/site-packages/radical/pilot/configs/resource_so.json
+       --output-json ${CONDA_PREFIX}/lib/python${python_major_minor}/site-packages/radical/pilot/configs/resource_so.json \
+       --env-path ${CONDA_PREFIX}

--- a/config/universe/post_install.sh
+++ b/config/universe/post_install.sh
@@ -16,4 +16,5 @@ install_jupyter_setup=yes
 python ${scriptdir}/tools/update_resource.py \
        --config ${config} \
        --base-json ${scriptdir}/templates/resource_so.json \
-       --output-json ${CONDA_PREFIX}/lib/python${python_major_minor}/site-packages/radical/pilot/configs/resource_so.json
+       --output-json ${CONDA_PREFIX}/lib/python${python_major_minor}/site-packages/radical/pilot/configs/resource_so.json \
+       --env-path ${CONDA_PREFIX}

--- a/tools/update_resource.py
+++ b/tools/update_resource.py
@@ -15,22 +15,39 @@ if __name__ == "__main__":
     parser.add_argument(
         "--output-json", type=str, required=True, help="The output JSON file."
     )
+    parser.add_argument(
+        "--env-path", type=str, required=True, help="The path or name of the python environment."
+    )
+    parser.add_argument(
+        "--env-type", type=str, required=False, help="The type of the python environment (e.g., conda, venv).",
+        default="conda"
+    )
+    parser.add_argument(
+        "--modules", type=str, nargs='*', required=False, help="List of modules to load before activating the environment."
+    )
     args = parser.parse_args()
 
     # Read the JSON file
     with open(args.base_json, "r") as file:
         base_config = json.load(file)
 
-    conda_prefix = os.environ.get("CONDA_PREFIX")
-    if conda_prefix is None:
-        raise EnvironmentError("CONDA_PREFIX environment variable is not set.")
-
     rp_config = base_config[args.config]
-    rp_config["virtenv"] = conda_prefix
+    rp_config["virtenv"] = args.env_path
 
+    if args.env_type == "conda":
+        rp_config["pre_bootstrap_0"][1] = f"conda activate {args.env_path}"
+        rp_config["task_pre_exec"][1] = f"conda activate {args.env_path}"
+        rp_config["launch_methods"]["SRUN"]["pre_exec_cached"][1] = f"conda activate {args.env_path}"
+    else:
+        rp_config["pre_bootstrap_0"][1] = f"source {args.env_path}/bin/activate"
+        rp_config["task_pre_exec"][1] = f"source {args.env_path}/bin/activate"
+        rp_config["launch_methods"]["SRUN"]["pre_exec_cached"][1] = f"source {args.env_path}/bin/activate"
 
-    rp_config["pre_bootstrap_0"][1] = f"conda activate {conda_prefix}"
-    rp_config["task_pre_exec"][1] = f"conda activate {conda_prefix}"
-    rp_config["launch_methods"]["SRUN"]["pre_exec_cached"][1] = f"conda activate {conda_prefix}"
+    if args.modules:
+        modules_to_load = " ".join(module for module in args.modules)
+        rp_config["pre_bootstrap_0"][0] = f"module load {modules_to_load}"
+        rp_config["task_pre_exec"][0] = f"module load {modules_to_load}"
+        rp_config["launch_methods"]["SRUN"]["pre_exec_cached"][0] = f"module load {modules_to_load}"
+
     with open(args.output_json, "w") as file:
         json.dump({args.config: rp_config}, file, indent=4)


### PR DESCRIPTION
The purpose for this PR is to generalize the python file that sets up the SO configuration for the campaign manager backend.

It introduces a few more arguments:

- env-path: The path or the name of the environment. This can be the same of `CONDA-PREFIX` for HPC created environments.
- env-type: `conda` or `venv`. This allows the script to correctly setup the activation of the environment. The default value is `conda`
- modules: If there are different modules to load, apart from the ones `soconda` expects, we can set this parameter. When set, the modules that are loaded before activating the environment change to what the user has defined.
