### PR TITLE
Add GPU mapmaker (sogma) to perlmutter build

### DIFF
--- a/config/common.txt
+++ b/config/common.txt
@@ -15,6 +15,7 @@ packaging
 #
 libopenblas=*=openmp_*
 libblas=*=*openblas
+blas=*=*openblas
 #
 # Install requirements of our local and pip packages
 #

--- a/config/perlmutter/packages_conda.txt
+++ b/config/perlmutter/packages_conda.txt
@@ -1,5 +1,14 @@
 # Adjust the default python version
 python=3.12
 #
+# GPU mapmaker
+cuda
+cupy
+nvidia-ml
+meson
+meson-python
+pybind11
+make
+#
 plotly
 plotly-resampler

--- a/config/perlmutter/packages_pip.txt
+++ b/config/perlmutter/packages_pip.txt
@@ -10,3 +10,6 @@ sotodlib==v0.6.16
 # The mapsims package has hard-coded versions of pysm3 and
 # pixell, which un-installs our versions of those packages.
 #https://github.com/galsci/mapsims/archive/main.tar.gz
+#
+# GPU mapmaker
+ksgpu

--- a/config/perlmutter/post_install.sh
+++ b/config/perlmutter/post_install.sh
@@ -20,3 +20,50 @@ python ${scriptdir}/tools/update_resource.py \
        --base-json ${scriptdir}/templates/resource_so.json \
        --output-json ${CONDA_PREFIX}/lib/python${python_major_minor}/site-packages/radical/pilot/configs/resource_so.json \
        --env-path ${CONDA_PREFIX}
+
+
+conda_exec env config vars set SOPATH=/global/cfs/cdirs/sobs
+conda_exec env config vars set PKG_CONFIG_PATH=$CONDA_PREFIX/lib/pkgconfig:$CONDA_PREFIX/share/pkgconfig:$PKG_CONFIG_PATH
+conda_exec deactivate
+conda_exec activate "${fullenv}"
+
+mkdir -p $CONDA_PREFIX/git
+
+echo ''
+echo ''
+cd $CONDA_PREFIX/git
+git clone https://github.com/amaurea/fast_g3.git
+cd $CONDA_PREFIX/git/fast_g3
+make clean && make -j4 && ln -sf $CONDA_PREFIX/git/fast_g3/fast_g3 $CONDA_PREFIX/lib/python${python_major_minor}/site-packages/fast_g3
+
+echo ''
+echo ''
+cd $CONDA_PREFIX/git
+git clone https://github.com/amaurea/cpu_mm.git
+cd $CONDA_PREFIX/git/cpu_mm
+make clean && make -j4 && ln -sf $CONDA_PREFIX/git/cpu_mm/python $CONDA_PREFIX/lib/python${python_major_minor}/site-packages/cpu_mm
+
+echo ''
+echo ''
+cd $CONDA_PREFIX/git
+git clone https://github.com/amaurea/gpu_mm.git
+cd $CONDA_PREFIX/git/gpu_mm
+make clean && make -j4 && ln -sf $CONDA_PREFIX/git/gpu_mm/gpu_mm $CONDA_PREFIX/lib/python${python_major_minor}/site-packages/gpu_mm
+
+echo ''
+echo ''
+cd $CONDA_PREFIX/git
+git clone https://github.com/amaurea/sogma.git
+cd $CONDA_PREFIX/git/sogma
+ln -sf $CONDA_PREFIX/git/sogma/python $CONDA_PREFIX/lib/python${python_major_minor}/site-packages/sogma
+ln -sf $CONDA_PREFIX/git/sogma/bin/sogma $CONDA_PREFIX/bin/sogma
+ln -sf $CONDA_PREFIX/git/sogma/bin/solist $CONDA_PREFIX/bin/solist
+ln -sf $CONDA_PREFIX/git/sogma/bin/soplanet $CONDA_PREFIX/bin/soplanet
+ln -sf $CONDA_PREFIX/git/sogma/bin/sosplit $CONDA_PREFIX/bin/sosplit
+
+echo ''
+echo ''
+cd $CONDA_PREFIX/git
+git clone https://github.com/amaurea/tenki.git
+ln -sf $CONDA_PREFIX/git/tenki/enplot $CONDA_PREFIX/bin/enplot
+


### PR DESCRIPTION
Not sure if this could merge into official build. There are bunch of ugly symlink installation to get the GPU mapmaker (sogma) to work. Several packages needs 1) clone repo 2) build 3) symlink to site-packages

https://github.com/simonsobs/soconda/blob/48ee3a3e8a404eb0a4ae06b6187ca292fa3552a1/config/perlmutter/post_install.sh#L25-L68