### PR TITLE
Add pip package to conda-build recipes

### DIFF
--- a/pkgs/moby2/meta.yaml
+++ b/pkgs/moby2/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - libblas * *openblas
     - python
     - setuptools
+    - pip
     - fftw
     - gsl
     - libactpol

--- a/pkgs/so3g/meta.yaml
+++ b/pkgs/so3g/meta.yaml
@@ -22,9 +22,6 @@ requirements:
     - cmake
     - make
     - llvm-openmp # [osx]
-    - setuptools
-    - python
-    - numpy
   host:
     - llvm-openmp # [osx]
     - libgomp # [linux]
@@ -32,6 +29,8 @@ requirements:
     - libblas * *openblas
     - openblas * *openmp*
     - python
+    - setuptools
+    - pip
     - numpy
     - scipy
     - boost

--- a/pkgs/toast/meta.yaml
+++ b/pkgs/toast/meta.yaml
@@ -25,14 +25,14 @@ requirements:
     - cmake
     - make
     - llvm-openmp # [osx]
-    - setuptools
-    - python
   host:
     - llvm-openmp # [osx]
     - libgomp # [linux]
     - libopenblas * *openmp*
     - libblas * *openblas
     - python
+    - setuptools
+    - pip
     - numpy
     - scipy
     - fftw


### PR DESCRIPTION
When I build conda environment today, it will fail to build qpoint due to missing pip module. It works fine before. So I add pip package to host dependencies.