### PR TITLE
`libactpol` and `moby2` pull `so3g` and `toast` compatible libraries

### DIFF
--- a/config/default/packages_local.txt
+++ b/config/default/packages_local.txt
@@ -1,9 +1,10 @@
-libactpol_deps
-libactpol
-moby2
 # Remove next line once toast-3.0 is on conda-forge,
 # and move to packages_conda.txt
 toast
 # Uncomment next line to build so3g from source, and
 # comment out line in packages_pip.txt.
 so3g
+#
+libactpol_deps
+libactpol
+moby2

--- a/config/della/packages_local.txt
+++ b/config/della/packages_local.txt
@@ -1,9 +1,10 @@
-libactpol_deps
-libactpol
-moby2
 # Remove next line once toast-3.0 is on conda-forge,
 # and move to packages_conda.txt
 toast
 # Uncomment next line to build so3g from source, and
 # comment out line in packages_pip.txt.
 so3g
+#
+libactpol_deps
+libactpol
+moby2

--- a/config/perlmutter/packages_local.txt
+++ b/config/perlmutter/packages_local.txt
@@ -1,10 +1,11 @@
-libactpol_deps
-libactpol
-moby2
 # Remove next line once toast-3.0 is on conda-forge,
 # and move to packages_conda.txt
 toast
 # Uncomment next line to build so3g from source, and
 # comment out line in packages_pip.txt.
 so3g
+#
+libactpol_deps
+libactpol
+moby2
 radical.pilot

--- a/config/site/packages_local.txt
+++ b/config/site/packages_local.txt
@@ -1,9 +1,10 @@
-libactpol_deps
-libactpol
-moby2
 # Remove next line once toast-3.0 is on conda-forge,
 # and move to packages_conda.txt
 toast
 # Uncomment next line to build so3g from source, and
 # comment out line in packages_pip.txt.
 so3g
+#
+libactpol_deps
+libactpol
+moby2

--- a/config/tiger3/packages_local.txt
+++ b/config/tiger3/packages_local.txt
@@ -1,10 +1,11 @@
-libactpol_deps
-libactpol
-moby2
 # Remove next line once toast-3.0 is on conda-forge,
 # and move to packages_conda.txt
 toast
 # Uncomment next line to build so3g from source, and
 # comment out line in packages_pip.txt.
 so3g
+#
+libactpol_deps
+libactpol
+moby2
 radical.pilot

--- a/config/universe/packages_local.txt
+++ b/config/universe/packages_local.txt
@@ -1,10 +1,11 @@
-libactpol_deps
-libactpol
-moby2
 # Remove next line once toast-3.0 is on conda-forge,
 # and move to packages_conda.txt
 toast
 # Uncomment next line to build so3g from source, and
 # comment out line in packages_pip.txt.
 so3g
+#
+libactpol_deps
+libactpol
+moby2
 radical.pilot

--- a/pkgs/libactpol/meta.yaml
+++ b/pkgs/libactpol/meta.yaml
@@ -37,6 +37,9 @@ requirements:
     - libxcrypt1   # [linux]
     # Not a dependency, force installing a NaMaster-compatible CFITSIO version
     - namaster >=2.4
+    # Not a dependency, force installing a compatible libraries
+    - so3g
+    - toast
   run:
     - llvm-openmp # [osx]
     - libopenblas * *openmp*

--- a/pkgs/moby2/meta.yaml
+++ b/pkgs/moby2/meta.yaml
@@ -40,6 +40,9 @@ requirements:
     - numba
     # Not a dependency, force installing a NaMaster-compatible GSL version
     - namaster >=2.4
+    # Not a dependency, force installing a compatible libraries
+    - so3g
+    - toast
   run:
     - llvm-openmp # [osx]
     - libopenblas * *openmp*


### PR DESCRIPTION
Include so3g and toast pacakges when building libactpol and moby2. This will make sure libactpol and moby2 pull compatible libraries. Since libactpol and moby2 needs so3g and toast packages, we need to build so3g and toast first.

resolve #89 